### PR TITLE
Allow definition of custom actions on each object

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ function StreamToMongo(options) {
 
 StreamToMongo.prototype._write = function (obj, encoding, done) {
   var self = this;
+
+  // Custom action definition
+  var action = this.options.action || function insert (obj, cb) {
+    this.collection.insert(obj, {w: 1}, cb);
+  };
+
   if (!this.db) {
     MongoClient.connect(this.options.db, function (err, db) {
       if (err) throw err;
@@ -25,9 +31,9 @@ StreamToMongo.prototype._write = function (obj, encoding, done) {
         self.db.close();
       });
       self.collection = db.collection(self.options.collection);
-      self.collection.insert(obj, { w: 1 }, done);
+      action.call(self, obj, done);
     });
   } else {
-    self.collection.insert(obj, { w: 1 }, done);
+    action.call(self, obj, done);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stream-to-mongo",
+  "name": "adamvr-stream-to-mongo",
   "version": "0.1.5",
   "description": "Write a stream of objects to a Mongo database",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "adamvr-stream-to-mongo",
+  "name": "stream-to-mongo",
   "version": "0.1.5",
   "description": "Write a stream of objects to a Mongo database",
   "main": "index.js",


### PR DESCRIPTION
Allows specification of custom actions using the `action` option key.

``` javascript
var mongoStream = require('stream-to-mongo')({db: 'mongodb://localhost/test', collection: 'test', action: upsert});

function upsert (object, done) {
  this.collection.update({_id: object._id}, object, {upsert: true}, done);
}
```
